### PR TITLE
modify the function of parse_size()

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -181,10 +181,10 @@ char *pretty_print_size(int64_t inp) {
 }
 
 /*
- *    Convert ASCII string to int64_t number
- *		XXX: the parameter of (inp) must can't be a 
- *			character constant, the function will 
- *			change it through (inp[len-1] = '\0');
+ *  Convert ASCII string to int64_t number
+ *    XXX: the parameter of (inp) must can't be a 
+ *		character constant, the function will 
+ *		change it through (inp[len-1] = '\0');
  */
 int64_t parse_size(char *inp) {
   char *tp;
@@ -210,7 +210,7 @@ int64_t parse_size(char *inp) {
 
   val = strtod(inp, &tp);
 
-  if (val <= 0 || tp != '\0') fatal(errstr);
+  if (val <= 0 || *tp != '\0') fatal(errstr);
 
   return (int64_t) (mult*val);
 }


### PR DESCRIPTION
have attention on he parameter of (inp) must can't be a character constant, the function will change it through (inp[len-1] = '\0'), and the function strtod() second parameter may use like this:  if (val <= 0 || *tp != '\0') fatal(errstr);
