### PR TITLE
New option to wait for the daemon to finish mlocking before exiting.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ upcoming
   * Patch from Federico Lucifredi: Avoid ugly NaNs in output
   * Full OS X support: msync(2) evicts pages on this system
   * HP-UX support from Shane Seymour (thanks!)
+  * Add option to wait for daemon mode to finish mlocking.
 
 0.7.3
   * Solaris support for page eviction

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -67,6 +67,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/mman.h>
+#include <sys/wait.h>
 #include <limits.h>
 #include <inttypes.h>
 #include <dirent.h>
@@ -97,9 +98,18 @@ int o_lockall=0;
 int o_daemon=0;
 int o_followsymlinks=0;
 size_t o_max_file_size=500*1024*1024;
+int o_wait=0;
 
+int exit_pipe[2];
 
+int daemon_pid;
 
+void send_exit_signal(char code) {
+  if (daemon_pid == 0 && o_wait) {
+    if (write(exit_pipe[1], &code, 1) < 0)
+      fprintf(stderr, "vmtouch: FATAL: write: %s", strerror(errno));
+  }
+}
 
 void usage() {
   printf("\n");
@@ -113,6 +123,7 @@ void usage() {
   printf("  -d daemon mode\n");
   printf("  -m <size> max file size to touch\n");
   printf("  -f follow symbolic links\n");
+  printf("  -w wait until all pages are locked (only useful together with -d)\n");
   printf("  -v verbose\n");
   printf("  -q quiet\n");
   exit(1);
@@ -127,6 +138,7 @@ static void fatal(const char *fmt, ...) {
   va_end(ap);
 
   fprintf(stderr, "vmtouch: FATAL: %s\n", buf);
+  send_exit_signal(1);
   exit(1);
 }
 
@@ -141,22 +153,54 @@ static void warning(const char *fmt, ...) {
   if (!o_quiet) fprintf(stderr, "vmtouch: WARNING: %s\n", buf);
 }
 
+static void reopen_all() {
+  if (freopen("/dev/null", "r", stdin) == NULL ||
+      freopen("/dev/null", "w", stdout) == NULL ||
+      freopen("/dev/null", "w", stdout) == NULL)
+    fatal("freopen: %s", strerror(errno));
+}
+
+static int wait_for_child() {
+  int exit_read = 0;
+  char exit_value = 0;
+  int wait_status;
+
+  while (1) {
+    struct timeval tv;
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+    FD_SET(exit_pipe[0], &rfds);
+    if (select(exit_pipe[0] + 1, &rfds, NULL, NULL, &tv) < 0)
+      fatal("select: %s", strerror(errno));
+
+    if (waitpid(daemon_pid, &wait_status, WNOHANG) > 0)
+      fatal("daemon shut down unexpectedly");
+
+    if (FD_ISSET(exit_pipe[0], &rfds))
+      break;
+  }
+  exit_read = read(exit_pipe[0], &exit_value, 1);
+  if (exit_read < 0)
+    fatal("read: %s", strerror(errno));
+  return exit_value;
+}
 
 void go_daemon() {
-  int rv;
-
-  rv = fork();
-  if (rv == -1)
+  daemon_pid = fork();
+  if (daemon_pid == -1)
     fatal("fork: %s", strerror(errno));
-  if (rv) exit(0);
+  if (daemon_pid) {
+    if (o_wait)
+      exit(wait_for_child());
+    exit(0);
+  }
 
   if (setsid() == -1)
     fatal("setsid: %s", strerror(errno));
 
-  if (freopen("/dev/null", "r", stdin) == NULL ||
-      freopen("/dev/null", "w", stdout) == NULL ||
-      freopen("/dev/null", "w", stderr) == NULL)
-    fatal("freopen: %s", strerror(errno));
+  if (!o_wait) reopen_all();
 }
 
 
@@ -387,6 +431,11 @@ void vmtouch_file(char *path) {
     }
 
     if (o_touch) {
+#if defined(__linux__)
+      if (posix_fadvise(fd, 0, len_of_file, POSIX_FADV_WILLNEED))
+        warning("unable to posix_fadvise file %s (%s)", path, strerror(errno));
+#endif
+
       for (i=0; i<pages_in_file; i++) {
         junk_counter += ((char*)mem)[i*pagesize];
         mincore_array[i] = 1;
@@ -520,9 +569,12 @@ int main(int argc, char **argv) {
   struct timeval start_time;
   struct timeval end_time;
 
+  if (pipe(exit_pipe))
+    fatal("pipe: %s", strerror(errno));
+
   pagesize = sysconf(_SC_PAGESIZE);
 
-  while((ch = getopt(argc, argv,"tevqlLdfpb:m:")) != -1) {
+  while((ch = getopt(argc, argv,"tevqlLdfpb:m:w")) != -1) {
     switch(ch) {
       case '?': usage(); break;
       case 't': o_touch = 1; break;
@@ -533,8 +585,7 @@ int main(int argc, char **argv) {
                 o_touch = 1; break;
       case 'L': o_lockall = 1;
                 o_touch = 1; break;
-      case 'd': o_daemon = 1;
-                o_quiet = 1; break;
+      case 'd': o_daemon = 1; break;
       case 'f': o_followsymlinks = 1; break;
       case 'p':
         o_touch = 1;
@@ -549,6 +600,7 @@ int main(int argc, char **argv) {
         if (val != (int64_t) o_max_file_size) fatal("value for -m too big to fit in a size_t");
         break;
       }
+      case 'w': o_wait = 1; break;
     }
   }
 
@@ -567,7 +619,13 @@ int main(int argc, char **argv) {
 
   if (o_daemon) {
     if (!(o_lock || o_lockall)) fatal("daemon mode must be combined with -l or -L");
+    if (!o_wait) {
+      o_quiet = 1;
+      o_verbose = 0;
+   }
   }
+
+  if (o_wait && !o_daemon) fatal("wait mode must be combined with -d");
 
   if (o_quiet && o_verbose) fatal("invalid option combination: -q and -v");
 
@@ -593,6 +651,9 @@ int main(int argc, char **argv) {
 
     if (!o_quiet) printf("LOCKED %" PRId64 " pages (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
 
+    if (o_wait) reopen_all();
+
+    send_exit_signal(0);
     select(0, NULL, NULL, NULL, NULL);
     exit(0);
   }


### PR DESCRIPTION
The -w option can be used together with -d to:
- let the parent process wait for the child process (daemon) to mlock the files.
- Forward stdout and stderr from child to the parent until the files are mlocked.
  Also, if the daemon fails to mlock for any reason, the parent process will
  fail with the same exit code.

This is useful when you want to run vmtouch as a daemon, but still be able to wait
for files to be properly mlocked.
