### PR TITLE
Increase max file size and ignore hardlinked duplicates

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -109,6 +109,7 @@ int o_lockall=0;
 int o_daemon=0;
 int o_followsymlinks=0;
 int o_ignorehardlinkeduplictes=0;
+int o_raw=0;
 int64_t o_max_file_size=50UL*1024UL*1024UL*1024UL;
 int o_wait=0;
 
@@ -136,6 +137,7 @@ void usage() {
   printf("  -m <size> max file size to touch\n");
   printf("  -f follow symbolic links\n");
   printf("  -h also count hardlinked copies\n");
+  printf("  -r show raw output ('RAW x' where x is the number of resident bytes)\n");
   printf("  -w wait until all pages are locked (only useful together with -d)\n");
   printf("  -v verbose\n");
   printf("  -q quiet\n");
@@ -631,7 +633,7 @@ int main(int argc, char **argv) {
 
   pagesize = sysconf(_SC_PAGESIZE);
 
-  while((ch = getopt(argc, argv,"tevqlLdfhpb:m:w")) != -1) {
+  while((ch = getopt(argc, argv,"tevqlLdfhprb:m:w")) != -1) {
     switch(ch) {
       case '?': usage(); break;
       case 't': o_touch = 1; break;
@@ -645,6 +647,7 @@ int main(int argc, char **argv) {
       case 'd': o_daemon = 1; break;
       case 'f': o_followsymlinks = 1; break;
       case 'h': o_ignorehardlinkeduplictes = 1; break;
+      case 'r': o_raw = 1; break;
       case 'p':
         o_touch = 1;
         printf("%d %s %ld\n", sizeof(void*) == 4 ? 32 : 64,
@@ -718,19 +721,28 @@ int main(int argc, char **argv) {
 
   if (!o_quiet) {
     if (o_verbose) printf("\n");
-    printf("           Files: %" PRId64 "\n", total_files);
-    printf("     Directories: %" PRId64 "\n", total_dirs);
+    if (!o_raw) {
+      printf("           Files: %" PRId64 "\n", total_files);
+      printf("     Directories: %" PRId64 "\n", total_dirs);
+    }
     if (o_touch)
       printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
     else if (o_evict)
       printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
     else {
-      printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
-      printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
-      printf("%s  ", pretty_print_size(total_pages*pagesize));
-      printf(total_pages ? "%.3g%%\n" : "\n", 100.0*total_pages_in_core/total_pages);
+      if (o_raw) {
+        printf("RAW %" PRId64, total_pages_in_core*pagesize);
+        printf("\n");
+      } else {
+        printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
+        printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
+        printf("%s  ", pretty_print_size(total_pages*pagesize));
+        printf(total_pages ? "%.3g%%\n" : "\n", 100.0*total_pages_in_core/total_pages);
+      }
     }
-    printf("         Elapsed: %.5g seconds\n", (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+    if (!o_raw) {
+      printf("         Elapsed: %.5g seconds\n", (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+    }
   }
 
   return 0;


### PR DESCRIPTION
The first commit increases the maximum file size. Without it, only small files are considered by vmtouch.

The second (larger) commit introduces a new default behaviour that can be deactivated using the new switch -h.

Files that are copies using hardlinks are now not counted only once. As an example:

$ dd if=/dev/random of=first bs=10M count=1
$ cp -al first second
$ vmtouch first second # new behaviour
Files: 1
Directories: 0
Resident Pages: 2560/2560  10M/10M  100%
Elapsed: 0.000571 seconds
$ ./vmtouch -h first second # old behaviour
Files: 2
Directories: 0
Resident Pages: 5120/5120  20M/20M  100%
Elapsed: 0.000803 seconds

As you can see, the old behaviour (with -h) produces output which does not make a lot of sense, as only 10 MByte of real data are cached.

Please review my patches before applying them for good, as my C knowledge is very limited.
