### PR TITLE
Fix to work with glibc 2.20

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -51,6 +51,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Required for posix_fadvise() on some linux systems
 #define _XOPEN_SOURCE 600
 // Required for mincore() on some linux systems
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 #endif
 


### PR DESCRIPTION
`_BSD_SOURCE` is deprecated in glibc 2.20, causing a warning to be given.  Since vmtouch is compiled with `-Werror` by default, this also causes the compilation to fail.

According to the [feature_test_macros man page](http://man7.org/linux/man-pages/man7/feature_test_macros.7.html), the warning can be silenced while still allowing compatibility with older versions of glibc by defining *both* `_BSD_SOURCE` and `_DEFAULT_SOURCE`.
