### PR TITLE
Update debian packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,3 +9,6 @@
 
 override_dh_strip:
 	dh_strip --dbg-package=vmtouch-dbg
+
+override_dh_auto_install:
+	$(MAKE) PREFIX=$$(pwd)/debian/vmtouch/usr install

--- a/debian/vmtouch.install
+++ b/debian/vmtouch.install
@@ -1,1 +1,0 @@
-debian/tmp/usr/sbin/*                      usr/sbin/


### PR DESCRIPTION
Hello,

Debian packaging is currently broken, dpkg-buldpackage:

~~~
...
cc -Wall -O2 -g -o vmtouch vmtouch.c
pod2man --section 8 vmtouch.pod > vmtouch.8
mkdir -p /usr/local/bin
install -D -m0755 vmtouch /usr/local/bin/vmtouch
install: cannot create regular file ‘/usr/local/bin/vmtouch’: Permission denied
Makefile:15: recipe for target 'install' failed
make[1]: *** [install] Error 1
...
~~~

This patch overrides dh_auto_install to provide correct prefix.

Thanks,
Luka
