### PR TITLE
Implement page mode (-p)

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -438,6 +438,10 @@ void vmtouch_file(char *path) {
 
   if (max_len > 0 && (offset + max_len) < len_of_file) {
     len_of_range = max_len;
+  } else if (offset >= len_of_file) {
+    warning("file %s smaller than offset, skipping", path);
+    close(fd);
+    return;
   } else {
     len_of_range = len_of_file - offset;
   }

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -139,6 +139,7 @@ void usage() {
   printf("  -L lock pages in physical memory with mlockall(2)\n");
   printf("  -d daemon mode\n");
   printf("  -m <size> max file size to touch\n");
+  printf("  -p <range> use the specified portion instead of the entire file\n");
   printf("  -f follow symbolic links\n");
   printf("  -h also count hardlinked copies\n");
   printf("  -w wait until all pages are locked (only useful together with -d)\n");

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -285,20 +285,21 @@ void parse_range(char *inp) {
   token = strsep(&inp,"-");
   
   if (inp == NULL)
-    upper_range = parse_size(token);
+    upper_range = parse_size(token); // single value provided
   else {
     if (*token != '\0')
-      offset = parse_size(token);
+      offset = parse_size(token); // value before hyphen
     
     token = strsep(&inp,"-");    
     if (*token != '\0')
-      upper_range = parse_size(token);
+      upper_range = parse_size(token); // value after hyphen
 
-    if ((token = strsep(&inp,"-")) != NULL) fatal("malformed range");
+    if ((token = strsep(&inp,"-")) != NULL) fatal("malformed range: multiple hyphens");
   }
 
   if (upper_range) {
     if (upper_range <= offset) fatal("range limits out of order");
+
     max_len = upper_range - offset;
   }  
 }

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -494,7 +494,6 @@ void vmtouch_file(char *path) {
     if (o_touch) {
       for (i=0; i<pages_in_range; i++) {
         junk_counter += ((char*)mem)[i*pagesize];
-        if (!is_mincore_page_resident(mincore_array[i])) total_pages_in_core++;
         mincore_array[i] = 1;
 
         if (o_verbose) {
@@ -671,7 +670,6 @@ int main(int argc, char **argv) {
   char *prog = argv[0];
   struct timeval start_time;
   struct timeval end_time;
-  char *verb;
 
   if (pipe(exit_pipe))
     fatal("pipe: %s", strerror(errno));
@@ -762,13 +760,11 @@ int main(int argc, char **argv) {
     printf("           Files: %" PRId64 "\n", total_files);
     printf("     Directories: %" PRId64 "\n", total_dirs);
     if (o_touch)
-      verb = "   Touched";
-    else
-      verb = "  Resident";
-    if (o_evict)
+      printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
+    else if (o_evict)
       printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
     else {
-      printf("%s Pages: %" PRId64 "/%" PRId64 "  ", verb, total_pages_in_core, total_pages);
+      printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
       printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
       printf("%s  ", pretty_print_size(total_pages*pagesize));
       if (total_pages)

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -469,7 +469,6 @@ void vmtouch_file(char *path) {
     fatal("cache eviction not (yet?) supported on this platform");
 #endif
   } else {
-    int64_t pages_in_core=0;
     double last_chart_print_time=0.0, temp_time;
     char *mincore_array = malloc(pages_in_range);
     if (mincore_array == NULL) fatal("Failed to allocate memory for mincore array (%s)", strerror(errno));
@@ -478,7 +477,6 @@ void vmtouch_file(char *path) {
     if (mincore(mem, len_of_range, (void*)mincore_array)) fatal("mincore %s (%s)", path, strerror(errno));
     for (i=0; i<pages_in_range; i++) {
       if (is_mincore_page_resident(mincore_array[i])) {
-        pages_in_core++;
         total_pages_in_core++;
       }
     }

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -279,9 +279,14 @@ int64_t parse_size(char *inp) {
   return (int64_t) (mult*val);
 }
 
+int64_t bytes2pages(int64_t bytes) {
+  return (bytes+pagesize-1) / pagesize;
+}
+
 void parse_range(char *inp) {
   char *token;
   int64_t upper_range=0;
+  int64_t lower_range=0;
   
   token = strsep(&inp,"-");
   
@@ -289,7 +294,7 @@ void parse_range(char *inp) {
     upper_range = parse_size(token); // single value provided
   else {
     if (*token != '\0')
-      offset = parse_size(token); // value before hyphen
+      lower_range = parse_size(token); // value before hyphen
     
     token = strsep(&inp,"-");    
     if (*token != '\0')
@@ -298,15 +303,14 @@ void parse_range(char *inp) {
     if ((token = strsep(&inp,"-")) != NULL) fatal("malformed range: multiple hyphens");
   }
 
+  // offset must be multiple of pagesize
+  offset = bytes2pages(lower_range) * pagesize;
+
   if (upper_range) {
     if (upper_range <= offset) fatal("range limits out of order");
 
     max_len = upper_range - offset;
   }  
-}
-
-int64_t bytes2pages(int64_t bytes) {
-  return (bytes+pagesize-1) / pagesize;
 }
 
 int aligned_p(void *p) {

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -487,6 +487,7 @@ void vmtouch_file(char *path) {
     if (o_touch) {
       for (i=0; i<pages_in_range; i++) {
         junk_counter += ((char*)mem)[i*pagesize];
+        if (!is_mincore_page_resident(mincore_array[i])) total_pages_in_core++;
         mincore_array[i] = 1;
 
         if (o_verbose) {
@@ -663,6 +664,7 @@ int main(int argc, char **argv) {
   char *prog = argv[0];
   struct timeval start_time;
   struct timeval end_time;
+  char *verb;
 
   if (pipe(exit_pipe))
     fatal("pipe: %s", strerror(errno));
@@ -753,11 +755,13 @@ int main(int argc, char **argv) {
     printf("           Files: %" PRId64 "\n", total_files);
     printf("     Directories: %" PRId64 "\n", total_dirs);
     if (o_touch)
-      printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
-    else if (o_evict)
+      verb = "   Touched";
+    else
+      verb = "  Resident";
+    if (o_evict)
       printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
     else {
-      printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
+      printf("%s Pages: %" PRId64 "/%" PRId64 "  ", verb, total_pages_in_core, total_pages);
       printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
       printf("%s  ", pretty_print_size(total_pages*pagesize));
       if (total_pages)

--- a/vmtouch.pod
+++ b/vmtouch.pod
@@ -52,6 +52,10 @@ Daemon mode. After performing the crawl, disassociate from the terminal and run 
 
 Maximum file size to map into virtual memory. Files that are larger than this will be skipped. Examples: 4096, 4k, 100M, 1.5G. The default is 500M.
 
+=item -p <size range> or <size>
+
+Page mode. Maps the portion of the file specified by a range instead of the entire file. Size format same as for C<-m>. Omitted range start (end) value means start (end) of file. Single <size> value is equivalent to -<size>, i.e. map the first <size> bytes. Examples: 4k-50k, 100M-2G, -5M, -.
+
 =item -f
 
 Follow symbolic links. With this option, vmtouch will descend into symbolic links that point to directories and will touch regular files pointed to by symbolic links. Symbolic link loops are detected and issue warnings.


### PR DESCRIPTION
Implements page mode, as described in TODO.

A curiosity I noticed while testing is that (on Linux at least) mmap actually maps in chunks of 32 pages, while posix_fadvise evicts exactly what it is told to. So if you use the same range to first touch and then evict a portion of a file, some pages just outside that range will still remain in VM. But since all pages within the range are properly touched/evicted, it's not a problem.