### PR TITLE
fix debian packaging after README convert

### DIFF
--- a/debian/vmtouch.docs
+++ b/debian/vmtouch.docs
@@ -1,2 +1,2 @@
-README
+README.md
 TODO


### PR DESCRIPTION
Hi, `debian/vmtouch.docs` contained reference to the old non-markdown README file and packaging failed in pbuilder.