### PR TITLE
Fix: catch parsing double values that are too large.

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -75,6 +75,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <math.h>
 #include <search.h>
 
 /*
@@ -275,7 +276,7 @@ int64_t parse_size(char *inp) {
 
   val = strtod(inp, &tp);
 
-  if (val <= 0 || *tp != '\0') fatal(errstr);
+  if (val <= 0 || val == HUGE_VAL || *tp != '\0') fatal(errstr);
 
   return (int64_t) (mult*val);
 }


### PR DESCRIPTION
This commit modifies `parse_size` to detect when the given value is too large
to fit in a `double`.

Closes #26

----

I wasn't sure how to test this thoroughly. It works for me, but I only have an x86_64 Linux host available. Are this header and `HUGE_VAL` available on all target platforms?