### PR TITLE
Added options -o and -r to save/read a list of files to use

### DIFF
--- a/vmtouch.pod
+++ b/vmtouch.pod
@@ -68,6 +68,14 @@ Can be specified multiple times. Ignores files and directories that match any of
 
 Can be specified multiple times. Only processes filenames matching one or more of the provided patterns. The pattern may include wildcards (remember to escape them from your shell). Example: vmtouch -I '*.c' -I '*.h' .
 
+=item -o
+
+Output mode. While crawling, it only prints paths when it contains pages in memory. Useful together with C<-r>. Example: vmtouch -o . > file_list.txt
+
+=item -r <filename>
+
+Read mode. It treats every line in the file as a pattern for -I. Useful together with C<-o>. Example: vmtouch -r  file_list.txt -t .
+
 =item -v
 
 Verbose mode. While crawling, print out every file being processed along with its total number of pages and the number of its pages that are currently resident in memory to standard output.


### PR DESCRIPTION
Not sure if you want this, but since I wanted it, I thought I'd share it. (If you don't want to merge, I completely understand; I'll personally be using my fork in that case)

## Use case:
You want to preload a certain program, let's say the Intellij IDEA located in `/opt/idea`. Let's say this is a huge directory, and you only want to preload the part of the program which it requires to start the program. To reduce the time needed to start it. 

First you make sure none of it is in memory. Then you start the Intellij IDEA. Now you run `vmtouch -o /opt/idea > ~/idea_preload.txt`. 

Now if you were to preload it (perhaps on boot), then you could simply do `vmtouch -l -r ~/idea_preload.txt /opt/idea` and you're good to go. 

## Caveats:
Using `-r` is slower than not using `-r`, because we're linearly going through every single entry in the list. Some kind of parsing-tree might be faster, but doing that in C sounds like a nightmare. 

----

Anyway, it's here if you want it. 