### PR TITLE
Turn on C99 option in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINDIR?=	$(PREFIX)/bin
 MANDIR?=	$(PREFIX)/man/man8
 
 CC?=		cc
-CFLAGS+=	-Wall -O2 -g
+CFLAGS+=	-Wall -O2 -g -std=c99
 
 all: vmtouch vmtouch.8
 


### PR DESCRIPTION
It solves the error that I encountered when compiling the code:
vmtouch.c: In function ‘is_ignored’:
vmtouch.c:657: error: ‘for’ loop initial declarations are only allowed in C99 mode
vmtouch.c:657: note: use option -std=c99 or -std=gnu99 to compile your code
vmtouch.c: In function ‘is_filename_filtered’:
vmtouch.c:680: error: ‘for’ loop initial declarations are only allowed in C99 mode
make: *** [vmtouch] Error 1