### PR TITLE
support staged installs using DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,11 @@ vmtouch.8: vmtouch.pod
 	pod2man --section 8 --center "System Manager's Manual" --release " " vmtouch.pod > vmtouch.8
 
 install: vmtouch vmtouch.8
-	mkdir -p $(BINDIR) $(MANDIR)
-	install -m 0755 vmtouch $(BINDIR)/vmtouch
-	install -m 0644 vmtouch.8 $(MANDIR)/vmtouch.8
+	install -Dm 0755 vmtouch $(DESTDIR)$(BINDIR)/vmtouch
+	install -Dm 0644 vmtouch.8 $(DESTDIR)$(MANDIR)/vmtouch.8
 
 clean:
 	rm -f vmtouch vmtouch.8
 
 uninstall:
-	rm $(BINDIR)/vmtouch $(MANDIR)/vmtouch.8
+	rm $(DESTDIR)$(BINDIR)/vmtouch $(DESTDIR)$(MANDIR)/vmtouch.8


### PR DESCRIPTION
Necessary for creating packages where the `PREFIX` differs from where the
package is created.  For example: `make PREFIX=/usr DESTDIR="$pkgdir" install`
