### PR TITLE
Create snapcraft.yaml to enable snap creation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: vmtouch
+version: git
+summary: Portable file system cache diagnostics and control
+description: |
+  vmtouch is a tool for learning about and controlling the file system cache of
+  unix and unix-like systems. It is BSD licensed so you can basically do
+  whatever you want with it..
+
+grade: stable
+confinement: classic
+
+apps:
+  vmtouch:
+    command: usr/local/bin/vmtouch
+
+parts:
+  vmtouch:
+    plugin: make
+    source: https://github.com/hoytech/vmtouch.git
+    source-type: git


### PR DESCRIPTION
I recently discovered vmtouch (late to the party as ever) and noticed it's not shipped in my Linux distro of choice, Ubuntu. So I thought I'd make a snap [1] to make that easier.

Adding this snapcraft.yaml will enable you to easily distribute vmtouch as a classic snap for multiple releases of Ubuntu and all flavours, derivatives and many other distributions [2]. Snaps are universal software packages for Linux. Building a snap using this yaml can be done with the snapcraft tool, or the free online build service at build.snapcraft.io. If the latter us used, then every commit will trigger a build to the edge channel in the store. Adventurous uses can test that with "snap install vmtouch --edge --classic". If you then chose to push out a stable release to the stable channel in the store, more conservative users can "snap install vmtouch --classic" and just track the stable updates.

If accepted and merged, you can visit build.snapcraft.io and hook it up to your master branch, sign into the store and register the name 'vmtouch' and you're done. Builds will happen automatically and be available within minutes to millions of Ubuntu and other Linux users.

If you have any questions, feel free to reply here, or visit snapcraft.io. 

[1] - http://snapcraft.io/
[2] - https://snapcraft.io/docs/core/install