### PR TITLE
Can do mincore warning

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -496,7 +496,7 @@ static int can_do_mincore(struct stat *st) {
   }
 
   uid_t uid = getuid();
-  return (st->st_uid == uid && (st->st_mode&S_IWUSR)) ||
+  return st->st_uid == uid ||
          (st->st_gid == getgid() && (st->st_mode&S_IWGRP)) ||
          (st->st_mode&S_IWOTH) ||
          uid == 0;

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -91,6 +91,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Used to find size of block devices
 #include <sys/ioctl.h>
 #include <sys/mount.h>
+// Used to check kernal version to know if mincore reports correctly
+#include <sys/utsname.h>
 #endif
 
 /*
@@ -469,7 +471,37 @@ void print_page_residency_chart(FILE *out, char *mincore_array, int64_t pages_in
 }
 
 
+#ifdef __linux__
+// check if mincore will report correctly, due side-channel vulnerabilities
+// from 5.2+ it only reports if process has write permission to the file
+// https://lwn.net/Articles/778437/
+static int can_do_mincore(struct stat *st) {
 
+  struct utsname utsinfo;
+  if (uname(&utsinfo) == 0) {
+    unsigned long ver[16];
+    int i=0;
+    char *p = utsinfo.release;
+    while (*p) {
+      if (isdigit(*p)) {
+          ver[i] = strtol(p, &p, 10);
+          i++;
+      } else {
+          p++;
+      }
+    }
+    // kernal < 5.2
+    if (ver[0]<5 && ver[1]<2)
+      return 1;
+  }
+
+  uid_t uid = getuid();
+  return (st->st_uid == uid && (st->st_mode&S_IWUSR)) ||
+         (st->st_gid == getgid() && (st->st_mode&S_IWGRP)) ||
+         (st->st_mode&S_IWOTH) ||
+         uid == 0;
+}
+#endif
 
 
 void vmtouch_file(char *path) {
@@ -590,6 +622,11 @@ void vmtouch_file(char *path) {
 
     if (o_verbose) {
       printf("%s\n", path);
+#ifdef __linux__
+      if (!can_do_mincore(&sb)) {
+        warning("Process does not have write permission, residency chart will not be accurate");
+      }
+#endif
       last_chart_print_time = gettimeofday_as_double();
       print_page_residency_chart(stdout, mincore_array, pages_in_range);
     }

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -491,7 +491,7 @@ static int can_do_mincore(struct stat *st) {
       }
     }
     // kernal < 5.2
-    if (ver[0]<5 && ver[1]<2)
+    if (ver[0]<5||ver[1]<2)
       return 1;
   }
 


### PR DESCRIPTION
As reported by #74, on Kernal 5.2+ mincore does not report correctly if you don't have write permission. Touch and evict still work as expect it's just the reporting that is wrong. This PR adds a runtime `can_do_mincore` function for ``__linux__`` which checks the Kernal version and if the user running the process has write permission to the file. If ``o_verbose`` and vmtouch can't get accurate information it issues a warning: **vmtouch: WARNING: Process does not have write permission, residency chart will not be accurate**.

Actual kernal check:
https://github.com/torvalds/linux/blob/b7a16c7ad790d0ecb44dcb08a6a75d0d0455ab5f/mm/mincore.c#L181-L195

Example:

```shell
[john@machine vmtouch]$ ./vmtouch -v /nvme/arthor/pubchem.smi.atdb
/nvme/arthor/pubchem.smi.atdb
vmtouch: WARNING: Process does not have write permission, residency chart will not be accurate
[OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO] 3543272/3543272

           Files: 1
     Directories: 0
  Resident Pages: 3543272/3543272  13G/13G  100%
         Elapsed: 0.014981 seconds
# sudo can see the residency correctly and doesn't get a warning
[john@machine vmtouch]$ sudo ./vmtouch -v /nvme/arthor/pubchem.smi.atdb
/nvme/arthor/pubchem.smi.atdb
[OOOOOOOOOOOOOOOo                                            ] 904352/3543272

           Files: 1
     Directories: 0
  Resident Pages: 904352/3543272  3G/13G  25.5%
         Elapsed: 0.13137 seconds
# allow group/other write access, residency is correct - no warning
[john@machine vmtouch]$ sudo chmod ugo+w /nvme/arthor/pubchem.smi.atdb
[john@machine vmtouch]$ ./vmtouch -v /nvme/arthor/pubchem.smi.atdb
/nvme/arthor/pubchem.smi.atdb
[OOOOOOOOOOOOOOOo                                            ] 904352/3543272

           Files: 1
     Directories: 0
  Resident Pages: 904352/3543272  3G/13G  25.5%
         Elapsed: 0.13547 seconds
```