### PR TITLE
Add a completion function for zsh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PREFIX?=	/usr/local
 BINDIR?=	$(PREFIX)/bin
 MANDIR?=	$(PREFIX)/share/man/man8
+ZSHDIR?=	$(PREFIX)/share/zsh/site-functions
 
 CC?=		cc
 CFLAGS+=	-Wall -O2 -g -std=c99
@@ -15,13 +16,14 @@ vmtouch: vmtouch.c
 vmtouch.8: vmtouch.pod
 	pod2man --section 8 --center "System Manager's Manual" --release " " vmtouch.pod > vmtouch.8
 
-install: vmtouch vmtouch.8
-	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)
+install: vmtouch vmtouch.8 _vmtouch
+	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR) $(DESTDIR)$(ZSHDIR)
 	install -m 0755 vmtouch $(DESTDIR)$(BINDIR)/vmtouch
 	install -m 0644 vmtouch.8 $(DESTDIR)$(MANDIR)/vmtouch.8
+	install -m 0644 _vmtouch $(DESTDIR)$(ZSHDIR)/_vmtouch
 
 clean:
 	rm -f vmtouch vmtouch.8
 
 uninstall:
-	rm $(DESTDIR)$(BINDIR)/vmtouch $(DESTDIR)$(MANDIR)/vmtouch.8
+	rm $(DESTDIR)$(BINDIR)/vmtouch $(DESTDIR)$(MANDIR)/vmtouch.8 $(DESTDIR)$(ZSHDIR)/_vmtouch

--- a/_vmtouch
+++ b/_vmtouch
@@ -1,0 +1,43 @@
+#compdef vmtouch
+
+# Completion function for zsh
+
+local curcontext="$curcontext" desc="upper"
+local -a state line suf
+local size range
+
+# _numbers only exists in newer versions of zsh
+if (( $+functions[_numbers] )); then
+  size=":_numbers -u bytes size k m g"
+  range=":->ranges"
+fi
+
+_arguments -C -s -S -A "-*" \
+  '(-e)-t[touch pages into memory]' \
+  '(-t -l -L)-e[evict pages from memory]' \
+  '(-e -L -t)-l[lock pages in physical memory with mlock(2)]' \
+  '(-e -l -t)-L[lock pages in physical memory with mlockall(2)]' \
+  '(-e)-d[daemon mode]' \
+  "-m+[specify max file size to touch]:size$size" \
+  "-p+[use the specified portion instead of the entire file]:range$range" \
+  '-f[follow symbolic links]' \
+  "-F[don't crawl different filesystems]" \
+  '-h[also count hardlinked copies]' \
+  '-i+[ignore files and directories that match specified pattern]:pattern' \
+  '-I+[only process files that match specified pattern]:pattern' \
+  '-b+[get files or directories from the list file]:list file:_files' \
+  '-0[in batch mode (-b) separate paths with NUL byte instead of newline]' \
+  '(-q -v)-w[wait until all pages are locked (only useful together with -d)]' \
+  '-P[write a pidfile (only useful together with -l or -L)]:pid file:_files' \
+  '(-q)-o+[output in machine friendly format]:format:((kv\:key=value\ pairs))' \
+  '(-q)-v[verbose]' \
+  '(-o -v)-q[quiet mode]' \
+  '*:file or directory:_files' && return
+
+[[ -z $state ]] && return 1 # no completion matches added
+
+if ! compset -P 1 '*-'; then
+  compset -S '-*' || suf=( -q -S- )
+  desc=lower
+fi
+_numbers $suf -u bytes "$desc range" k m g

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -177,7 +177,7 @@ void usage() {
   printf("  -f follow symbolic links\n");
   printf("  -F don't crawl different filesystems\n");
   printf("  -h also count hardlinked copies\n");
-  printf("  -i <pattern> ignores files and directories that match this pattern\n");
+  printf("  -i <pattern> ignore files and directories that match this pattern\n");
   printf("  -I <pattern> only process files that match this pattern\n");
   printf("  -b <list file> get files or directories from the list file\n");
   printf("  -0 in batch mode (-b) separate paths with NUL byte instead of newline\n");
@@ -994,15 +994,10 @@ int main(int argc, char **argv) {
   argc -= optind;
   argv += optind;
 
-  if (o_touch) {
-    if (o_evict) fatal("invalid option combination: -t and -e");
-  }
-
-  if (o_evict) {
-    if (o_lock) fatal("invalid option combination: -e and -l");
-  }
-
+  if (o_evict && o_lock) fatal("invalid option combination: -e and -l");
+  if (o_evict && o_lockall) fatal("invalid option combination: -e and -L");
   if (o_lock && o_lockall) fatal("invalid option combination: -l and -L");
+  if (o_touch && o_evict) fatal("invalid option combination: -t and -e");
 
   if (o_daemon) {
     if (!(o_lock || o_lockall)) fatal("daemon mode must be combined with -l or -L");


### PR DESCRIPTION
This adds a file containing an autoloadable completion function for use with zsh so that zsh users can get hints on vmtouch usage with their tab key.

In the process, I noticed that because the `-l` option implies `-t` and sets `o_touch`, you get an error message for the `-t`/`-e` combination when combining `-l` with `-e`. The `-l`/`-e` check was thus dead code. By rearranging it to check `-t`/`-e` after `-l`/`-e`, error messages are better. I also added a similar line for `-L`/`-e`. There could be ways to refactor it so that instead of the error message being repeated you can use `%c` for each option letter.

For the option descriptions in the `usage()` function, you've used imperative mood form for all but one option. The exception is `-i` which starts with the word "ignores". I have changed it for consistency, both in `usage()` and when copying it for the zsh completion.

I've also added to the `Makefile` to install the completion.